### PR TITLE
FND-1551: BUGFIX idleReplicaCount should be omittable

### DIFF
--- a/charts/base/templates/_keda.tpl
+++ b/charts/base/templates/_keda.tpl
@@ -28,7 +28,9 @@ spec:
     {{- end }}
   pollingInterval: {{ .Values.keda.pollingInterval | default 30 }}
   cooldownPeriod: {{ .Values.keda.cooldownPeriod | default 300 }}
-  idleReplicaCount: {{ .Values.keda.idleReplicaCount | default 0 }}
+  {{ if .Values.keda.idleReplicaCount }}
+  idleReplicaCount: {{ .Values.keda.idleReplicaCount }}
+  {{ end }}
   minReplicaCount:  {{ .Values.keda.minReplicaCount | default 0 }}
   maxReplicaCount:  {{ .Values.keda.maxReplicaCount | default 100 }}
   {{- with .Values.keda.fallback }}


### PR DESCRIPTION
In some cases, you always need at least n pod running. Thus, you can omit this property and set minReplicaCount to n.

Example You set minReplicaCount to 1 and maxReplicaCount to 10. If there’s no activity on triggers, the target resource is scaled down to minReplicaCount (1). Once there are activities, the target resource will scale base on the HPA rule. If there’s no activity on triggers, the resource is again scaled down to minReplicaCount (1).